### PR TITLE
Add HaruDoc::useUTFEncodings() for libharu 2.3.0+

### DIFF
--- a/haru.c
+++ b/haru.c
@@ -2066,6 +2066,28 @@ static PHP_METHOD(HaruDoc, useCNTEncodings)
 }
 /* }}} */
 
+#if defined(HPDF_VERSION_ID) && HPDF_VERSION_ID >= 20300
+/* {{{ proto bool HaruDoc::useUTFEncodings()
+ Enable UTF-8 encoding */
+static PHP_METHOD(HaruDoc, useUTFEncodings)
+{
+	php_harudoc *doc = (php_harudoc *)zend_object_store_get_object(getThis() TSRMLS_CC);
+	HPDF_STATUS status;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+		return;
+	}
+
+	status = HPDF_UseUTFEncodings(doc->h);
+
+	if (php_haru_status_to_exception(status TSRMLS_CC)) {
+		return;
+	}
+	RETURN_TRUE;
+}
+/* }}} */
+#endif
+
 /* }}} */
 
 /* HaruPage methods {{{ */
@@ -5683,6 +5705,9 @@ static zend_function_entry harudoc_methods[] = { /* {{{ */
 	PHP_ME(HaruDoc, useCNSEncodings, 		arginfo_harudoc___void, 				ZEND_ACC_PUBLIC)
 	PHP_ME(HaruDoc, useCNTFonts, 			arginfo_harudoc___void, 				ZEND_ACC_PUBLIC)
 	PHP_ME(HaruDoc, useCNTEncodings, 		arginfo_harudoc___void, 				ZEND_ACC_PUBLIC)
+#if defined(HPDF_VERSION_ID) && HPDF_VERSION_ID >= 20300
+	PHP_ME(HaruDoc, useUTFEncodings, 		arginfo_harudoc___void, 				ZEND_ACC_PUBLIC)
+#endif
 	{NULL, NULL, NULL}
 };
 


### PR DESCRIPTION
Add HaruDoc::useUTFEncodings() and the 'UTF-8' encoder type if built with libharu 2.3.0 or greater.
